### PR TITLE
Removed redundant physical address property

### DIFF
--- a/src/PEditor/TabItems/SectionHeaders.xaml.cs
+++ b/src/PEditor/TabItems/SectionHeaders.xaml.cs
@@ -34,7 +34,7 @@ namespace PEditor.TabItems
                     VSize = sec.VirtualSize.ToHexString(),
                     VAddress = sec.VirtualAddress.ToHexString(),
                     PSize = sec.SizeOfRawData.ToHexString(),
-                    PAddress = sec.PhysicalAddress.ToHexString(),
+                    PAddress = sec.PointerToRawData.ToHexString(),
                     Flags = sec.Characteristics.ToHexString(),
                     RFlags = flags
                 });

--- a/src/PeNet/Structures/IMAGE_SECTION_HEADER.cs
+++ b/src/PeNet/Structures/IMAGE_SECTION_HEADER.cs
@@ -53,23 +53,15 @@ namespace PeNet.Structures
         }
 
         /// <summary>
-        ///     The raw (file) address of the section.
-        /// </summary>
-        public uint PhysicalAddress
-        {
-            get { return Buff.BytesToUInt32(Offset + 0x8); }
-            set { Buff.SetUInt32(Offset + 0x8, value); }
-        }
-
-        /// <summary>
         ///     Size of the section when loaded into memory. If it's bigger than
         ///     the raw data size, the rest of the section is filled with zeros.
         /// </summary>
         public uint VirtualSize
         {
-            get { return PhysicalAddress; }
-            set { PhysicalAddress = value; }
+            get { return Buff.BytesToUInt32(Offset + 0x8); }
+            set { Buff.SetUInt32(Offset + 0x8, value); }
         }
+
 
         /// <summary>
         ///     RVA of the section start in memory.


### PR DESCRIPTION
I might have missed something, but it seems the VirtualSize property of IMAGE_SECTION_HEADER was coupled to another property called PhysicalAddress which was actually referencing the VirtualSize field of the IMAGE_SECTION_HEADER structure. 
This PR fixes that, and updates the app to read from the PointerToRawData field instead, as it was actually displaying the wrong data before. 🙂 