### PR TITLE
Added parsing of Pdb information

### DIFF
--- a/src/PeNet/Structures/IMAGE_DEBUG_DIRECTORY.cs
+++ b/src/PeNet/Structures/IMAGE_DEBUG_DIRECTORY.cs
@@ -1,4 +1,6 @@
-﻿using System.Text;
+﻿using System;
+using System.Linq;
+using System.Text;
 using PeNet.Utilities;
 
 namespace PeNet.Structures
@@ -93,6 +95,36 @@ namespace PeNet.Structures
             get { return Buff.BytesToUInt32(Offset + 0x18); }
             set { Buff.SetUInt32(Offset + 0x18, value); }
         }
+
+        public Guid PdbSignature
+        {
+            get
+            {
+                var bytes = new byte[16];
+                Array.Copy(Buff, PointerToRawData + 4, bytes, 0, 16);
+                return new Guid(bytes);
+            }
+            set
+            {
+                Array.Copy(value.ToByteArray(), 0, Buff, PointerToRawData + 4, 16);
+            }
+        }
+
+        public uint PdbAge
+        {
+            get { return Buff.BytesToUInt32(PointerToRawData + 0x14); }
+            set { Buff.SetUInt32(PointerToRawData + 0x14, value); }
+        }
+
+        public string PdbPath
+        {
+            get
+            {
+                var bytes = Buff.Skip((int) PointerToRawData + 0x18).TakeWhile(x => x != 0x0).ToArray();
+                return Encoding.UTF8.GetString(bytes);
+            }
+        }
+
 
         /// <summary>
         ///     Convert all object properties to strings.

--- a/test/PeNet.Test/Structures/NetFrameworkConsole_Test.cs
+++ b/test/PeNet.Test/Structures/NetFrameworkConsole_Test.cs
@@ -1,4 +1,5 @@
-﻿using Xunit;
+﻿using System;
+using Xunit;
 
 namespace PeNet.Test.Structures
 {
@@ -9,11 +10,12 @@ namespace PeNet.Test.Structures
         [Fact]
         public void NetFameworkConsole_DataDirectory_COMDescripterSet()
         {
-            var dataDirectory = _peFile.ImageNtHeaders.OptionalHeader.DataDirectory[(int)Constants.DataDirectoryIndex.COM_Descriptor];
+            var dataDirectory = _peFile.ImageNtHeaders.OptionalHeader.DataDirectory[(int) Constants.DataDirectoryIndex.COM_Descriptor];
 
             Assert.Equal(0x2008u, dataDirectory.VirtualAddress);
             Assert.Equal(0x48u, dataDirectory.Size);
         }
+
         [Fact]
         public void NetFameworkConsole_IsSignatureValid()
         {
@@ -157,6 +159,25 @@ namespace PeNet.Test.Structures
             Assert.Equal(0x00, blob[0]);
             Assert.Equal(0x4E, blob[0x97]);
             Assert.Equal(0x00, blob[0x14F]);
+        }
+
+        [Fact]
+        public void NetFrameworkConsole_ImageDebugDirectory_ParseCorrectValues()
+        {
+            var debug = _peFile.ImageDebugDirectory;
+
+            Assert.Equal(0x0u, debug.Characteristics);
+            Assert.Equal(0x59C7FCFDu, debug.TimeDateStamp);
+            Assert.Equal(0x0u, debug.MajorVersion);
+            Assert.Equal(0x0u, debug.MinorVersion);
+            Assert.Equal(0x2u, debug.Type);
+            Assert.Equal(0x11Cu, debug.SizeOfData);
+            Assert.Equal(0x000027F0u, debug.AddressOfRawData);
+            Assert.Equal(0x000009F0u, debug.PointerToRawData);
+            
+            Assert.Equal(Guid.Parse("089DBC29-C16A-44DA-8290-53544C40DD95"), debug.PdbSignature);
+            Assert.Equal(0x1u, debug.PdbAge);
+            Assert.Equal(@"C:\Users\stefa\Documents\Git\PeNet-Test-Executables\NetFrameworkConsole\obj\Release\NetFrameworkConsole.pdb", debug.PdbPath);
         }
     }
 }


### PR DESCRIPTION
I used [this](http://www.godevtool.com/Other/pdb.htm#top) as a reference. 

Output from `dumpbin /headers <file>`
```
        Time Type        Size      RVA  Pointer
    -------- ------- -------- -------- --------
    59C7FCFD cv           11C 000027F0      9F0    Format: RSDS, {089DBC29-C16A-44DA-8290-53544C40DD95}, 1, C:\Users\stefa\Documents\Git\PeNet-Test-Executables\NetFrameworkConsole\obj\Release\NetFrameworkConsole.pdb
```

I didn't add a setter for PDB file path because it's unclear (to me at least) whether there is a fixed space for it, or it needs to be inserted.

Resolves #52 