### PR TITLE
parse export directories with no function names correctly

### DIFF
--- a/src/PeNet/Parser/ExportedFunctionsParser.cs
+++ b/src/PeNet/Parser/ExportedFunctionsParser.cs
@@ -30,8 +30,8 @@ namespace PeNet.Parser
             var expFuncs = new ExportFunction[_exportDirectory.NumberOfFunctions];
 
             var funcOffsetPointer = _exportDirectory.AddressOfFunctions.RVAtoFileMapping(_sectionHeaders);
-            var ordOffset = _exportDirectory.AddressOfNameOrdinals.RVAtoFileMapping(_sectionHeaders);
-            var nameOffsetPointer = _exportDirectory.AddressOfNames.RVAtoFileMapping(_sectionHeaders);
+            var ordOffset = _exportDirectory.NumberOfNames == 0 ? 0 : _exportDirectory.AddressOfNameOrdinals.RVAtoFileMapping(_sectionHeaders);
+            var nameOffsetPointer = _exportDirectory.NumberOfNames == 0 ? 0 : _exportDirectory.AddressOfNames.RVAtoFileMapping(_sectionHeaders);
 
             //Get addresses
             for (uint i = 0; i < expFuncs.Length; i++)


### PR DESCRIPTION
Hey Stefan,

Love your project, but I came across an edge case today.

If the export directory's NumberOfNames is 0 then AddressOfNames and AddressOfNameOrdinals are not necessarily valid RVAs - and RVAtoFileMapping can throw an exception.  This means that the exports will not be correctly parsed.

Windows 10's C:\Windows\System32\profapi.dll is an example of such a PE file.

Cheers,

John