### PR TITLE
net48 support.

### DIFF
--- a/src/PeNet/FileParser/BufferFile.cs
+++ b/src/PeNet/FileParser/BufferFile.cs
@@ -4,6 +4,7 @@ using System.Text;
 
 namespace PeNet.FileParser
 {
+#if !NET48
     public class BufferFile : IRawFile
     {
         private Memory<byte> _buffer;
@@ -76,4 +77,79 @@ namespace PeNet.FileParser
             return oldLength;
         }
     }
+#else
+    public unsafe class BufferFile : IRawFile
+    {
+        private Memory<byte> _buffer;
+
+        public long Length => _buffer.Length;
+
+        public BufferFile(byte[] file) => _buffer = file;
+
+        public string ReadAsciiString(long offset)
+        {
+            var nullTerminator = byte.MinValue;
+
+            var stringLength = _buffer.Span.Slice((int)offset).IndexOf(nullTerminator);
+
+            return Encoding.ASCII.GetString(_buffer.Span.Slice((int)offset, stringLength));
+        }
+
+        public Span<byte> AsSpan(long offset, long length) => _buffer.Span.Slice((int) offset, (int) length);
+
+        public string ReadUnicodeString(long offset)
+        {
+            Span<byte> nullTerminator = stackalloc byte[] {byte.MinValue, byte.MinValue};
+
+            var stringLength = _buffer.Span.Slice((int)offset).IndexOf(nullTerminator) + 1;
+
+            return Encoding.Unicode.GetString(_buffer.Span.Slice((int)offset, stringLength));
+        }
+
+        public string ReadUnicodeString(long offset, long length) => Encoding.Unicode.GetString(_buffer.Span.Slice((int)offset, (int)length * 2));
+
+        public byte ReadByte(long offset) => _buffer.Span[(int) offset];
+
+        public uint ReadUInt(long offset) => MemoryMarshal.Read<uint>(_buffer.Span.Slice((int)offset));
+
+        public ulong ReadULong(long offset) => MemoryMarshal.Read<ulong>(_buffer.Span.Slice((int)offset));
+
+        public ushort ReadUShort(long offset) => MemoryMarshal.Read<ushort>(_buffer.Span.Slice((int)offset));
+
+        public void WriteByte(long offset, byte value) => _buffer.Span[(int) offset] = value;
+
+        public void WriteBytes(long offset, Span<byte> bytes) => bytes.CopyTo(_buffer.Span.Slice((int)offset));
+
+        public void WriteUInt(long offset, uint value) => MemoryMarshal.Write(_buffer.Span.Slice((int)offset), ref value);
+
+        public void WriteULong(long offset, ulong value) => MemoryMarshal.Write(_buffer.Span.Slice((int)offset), ref value);
+
+        public void WriteUShort(long offset, ushort value) => MemoryMarshal.Write(_buffer.Span.Slice((int)offset), ref value);
+
+        public byte[] ToArray() => _buffer.ToArray();
+
+        public void RemoveRange(long offset, long length)
+        {
+            var newBuffer = new Memory<byte>(new byte[_buffer.Length - length]);
+
+            _buffer.Slice(0, (int) offset).CopyTo(newBuffer);
+            _buffer.Slice((int)(offset + length)).CopyTo(newBuffer.Slice((int)offset));
+
+            _buffer = newBuffer;
+        }
+
+        public int AppendBytes(Span<byte> bytes)
+        {
+            var oldLength = _buffer.Length;
+
+            var newBuffer = new Memory<byte>(new byte[_buffer.Length + bytes.Length]);
+            _buffer.CopyTo(newBuffer);
+            bytes.CopyTo(newBuffer.Span.Slice(oldLength));
+            _buffer = newBuffer;
+
+            return oldLength;
+        }
+    }
+#endif
+
 }

--- a/src/PeNet/FileParser/MMFile.cs
+++ b/src/PeNet/FileParser/MMFile.cs
@@ -68,8 +68,11 @@ namespace PeNet.FileParser
             {
                 tmp[i] = (char)_va.ReadByte(offset + i);
             }
-
+#if NET48
+            return new string((char*)System.Runtime.CompilerServices.Unsafe.AsPointer(ref tmp[0]));
+#else
             return new string(tmp);
+#endif
         }
 
         public byte ReadByte(long offset)

--- a/src/PeNet/FileParser/StreamFile.cs
+++ b/src/PeNet/FileParser/StreamFile.cs
@@ -94,7 +94,11 @@ namespace PeNet.FileParser
             Span<byte> s = stackalloc byte[4];
             _stream.Seek(offset, SeekOrigin.Begin);
             _stream.Read(s);
+#if NET48
+            return BitConverter.ToUInt32(s.ToArray(), 0);
+#else
             return BitConverter.ToUInt32(s);
+#endif
         }
 
         public ulong ReadULong(long offset)
@@ -102,7 +106,11 @@ namespace PeNet.FileParser
             Span<byte> s = stackalloc byte[8];
             _stream.Seek(offset, SeekOrigin.Begin);
             _stream.Read(s);
+#if NET48
+            return BitConverter.ToUInt64(s.ToArray(), 0);
+#else
             return BitConverter.ToUInt64(s);
+#endif
         }
 
         public ushort ReadUShort(long offset)
@@ -110,7 +118,11 @@ namespace PeNet.FileParser
             Span<byte> s = stackalloc byte[2];
             _stream.Seek(offset, SeekOrigin.Begin);
             _stream.Read(s);
+#if NET48
+            return BitConverter.ToUInt16(s.ToArray(), 0);
+#else
             return BitConverter.ToUInt16(s);
+#endif
         }
 
         public byte[] ToArray()

--- a/src/PeNet/Header/Authenticode/AuthenticodeInfo.cs
+++ b/src/PeNet/Header/Authenticode/AuthenticodeInfo.cs
@@ -145,7 +145,11 @@ namespace PeNet.Header.Authenticode
             var asn1 = _contentInfo?.Content;
             if (asn1 is null) return null;
             var x = (Asn1Integer)asn1.Nodes[0].Nodes[4].Nodes[0].Nodes[1].Nodes[1]; // ASN.1 Path to signer serial number: /1/0/4/0/1/1
+#if NET48
+            return x.Value.ToHexString().Substring(2).ToUpper();
+#else
             return x.Value.ToHexString()[2..].ToUpper();
+#endif
         }
 
         public IEnumerable<byte>? ComputeAuthenticodeHashFromPeFile(HashAlgorithm hash)

--- a/src/PeNet/Header/ImpHash/ImportHash.cs
+++ b/src/PeNet/Header/ImpHash/ImportHash.cs
@@ -62,7 +62,11 @@ namespace PeNet.Header.ImpHash
             var parts = libraryName.ToLower().Split('.');
             var libName = "";
 
+#if NET48
+            if (parts.Length > 1 && exts.Contains(parts[parts.Length - 1]))
+#else
             if (parts.Length > 1 && exts.Contains(parts[^1]))
+#endif
             {
                 for (var i = 0; i < parts.Length - 1; i++)
                 {

--- a/src/PeNet/Header/Net/MetaDataStreamGuid.cs
+++ b/src/PeNet/Header/Net/MetaDataStreamGuid.cs
@@ -50,7 +50,11 @@ namespace PeNet.Header.Net
 
             for (var i = Offset; i < Offset + _size; i += 16)
             {
+#if NET48
+                guidsAndIndicies.Add(new Tuple<Guid, uint>(new Guid(PeFile.AsSpan(i, 16).ToArray()), (uint)guidsAndIndicies.Count + 1));
+#else
                 guidsAndIndicies.Add(new Tuple<Guid, uint>(new Guid(PeFile.AsSpan(i, 16)), (uint) guidsAndIndicies.Count + 1));
+#endif
             }
 
             return guidsAndIndicies;

--- a/src/PeNet/Header/Resource/CvInfoPdb70.cs
+++ b/src/PeNet/Header/Resource/CvInfoPdb70.cs
@@ -28,7 +28,11 @@ namespace PeNet.Header.Resource
         /// </summary>
         public Guid Signature
         {
+#if NET48
+            get => new Guid(PeFile.AsSpan(Offset + 4, 16).ToArray());
+#else
             get => new Guid(PeFile.AsSpan(Offset + 4, 16));
+#endif
             set => PeFile.WriteBytes(Offset + 4, value.ToByteArray());
         }
 

--- a/src/PeNet/NET48_Helpers.cs_
+++ b/src/PeNet/NET48_Helpers.cs_
@@ -1,0 +1,28 @@
+
+using System;
+using System.IO;
+using System.Text;
+
+namespace PeNet
+{
+	public static class NET48_Helpers
+	{
+        public static unsafe string GetString(this Encoding encoding, Span<byte> span)
+        {
+            return Encoding.ASCII.GetString((byte*)System.Runtime.CompilerServices.Unsafe.AsPointer(ref span[0]), span.Length);
+        }
+
+        public static int Read(this Stream stream, Span<byte> span)
+        {
+            byte[] buffer = new byte[span.Length];
+            int ret = stream.Read(buffer, 0, buffer.Length);
+            ((Span<byte>)buffer).CopyTo(span);
+            return ret;
+        }
+
+        public static void Write(this Stream stream, Span<byte> span)
+        {
+            stream.Write(span.ToArray(), 0, span.Length);
+        }
+	}
+}

--- a/src/PeNet/PeNet.csproj
+++ b/src/PeNet/PeNet.csproj
@@ -1,10 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net5.0;net48</TargetFrameworks>
     <Version>0.0.0</Version>
     <Nullable>enable</Nullable>
     <LangVersion>9</LangVersion>
     <WarningsAsErrors>CS8600;CS8602;CS8603;CS8625;CS8618;CS8604;CS8601</WarningsAsErrors>
+    <IsDotNetFramework Condition=" $(TargetFramework.StartsWith(net4)) ">true</IsDotNetFramework>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -42,6 +43,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net5.0|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net48|AnyCPU'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net48|AnyCPU'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
   
   <ItemGroup>
     <PackageReference Include="PeNet.Asn1" Version="1.5.1" />
@@ -50,5 +59,13 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\resource\icon.png" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(IsDotNetFramework)' == 'true' ">
+    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
+    <Compile Include="NET48_Helpers.cs_">
+      <Link>NET48_Helpers.cs</Link>
+    </Compile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
I try some simple change (no performance consideration) to make PeNet support for net48:
1. write some extension methods for Span<T> under net48.
2. use Unsafe's method to get Span<T>'s buffer address (i guess it may be unsafe in some situation)
3. get slice of Span<T> instead of using System.Index & System.Range feature that is not included by net48.

[PeNet.Asn1.csproj](https://github.com/secana/PeNet.Asn1/blob/master/src/PeNet.Asn1/PeNet.Asn1.csproj) is also need to be compiled with net48.