### PR TITLE
Fixes for OOM issue

### DIFF
--- a/src/PeNet/Header/Resource/StringTable.cs
+++ b/src/PeNet/Header/Resource/StringTable.cs
@@ -147,8 +147,13 @@ namespace PeNet.Header.Resource
             while (currentOffset < Offset + WLength)
             {
                 currentOffset += currentOffset.PaddingBytes(32);
-                children.Add(new TString(PeFile, currentOffset));
-                currentOffset += children.Last().WLength;
+
+                var ts = new TString(PeFile, currentOffset);
+                if (ts.WLength == 0)
+                    break;
+
+                currentOffset += ts.WLength;
+                children.Add(ts);
             }
 
             return children.ToArray();

--- a/src/PeNet/Header/Resource/VarFileInfo.cs
+++ b/src/PeNet/Header/Resource/VarFileInfo.cs
@@ -79,8 +79,12 @@ namespace PeNet.Header.Resource
 
             while (currentOffset < Offset + WLength)
             {
-                values.Add(new Var(PeFile, currentOffset));
-                currentOffset += values.Last().WLength;
+                var v = new Var(PeFile, currentOffset);
+                if (v.WLength == 0)
+                    break;
+
+                currentOffset += v.WLength;
+                values.Add(v);
             }
 
             return values.ToArray();

--- a/src/PeNet/NET48_Helpers.cs_
+++ b/src/PeNet/NET48_Helpers.cs_
@@ -9,7 +9,7 @@ namespace PeNet
 	{
         public static unsafe string GetString(this Encoding encoding, Span<byte> span)
         {
-            return Encoding.ASCII.GetString((byte*)System.Runtime.CompilerServices.Unsafe.AsPointer(ref span[0]), span.Length);
+            return encoding.GetString((byte*)System.Runtime.CompilerServices.Unsafe.AsPointer(ref span[0]), span.Length);
         }
 
         public static int Read(this Stream stream, Span<byte> span)


### PR DESCRIPTION
Fixed OOM in StringTable and VarFileInfo parsers
Fixed the encoding for the .NET Framework version

This PR has fixes similar to the one in the https://github.com/secana/PeNet/pull/200 pull request that was merged recently.
Also the small issue with the encoding gives bad offset which actually caused OOM in my case so I've added the fix for that too