### PR TITLE
Prevent attempts to get invalid offsets on corrupted samples

### DIFF
--- a/src/PeNet/HeaderParser/Pe/DataDirectoryParsers.cs
+++ b/src/PeNet/HeaderParser/Pe/DataDirectoryParsers.cs
@@ -91,16 +91,18 @@ namespace PeNet.HeaderParser.Pe
         {
             try
             {
-                var vsVersionOffset = ImageResourceDirectory
-                    ?.DirectoryEntries?.FirstOrDefault(e => e?.ID == (int) ResourceGroupIdType.Version) // Root
+                var resourceDataEntry = ImageResourceDirectory
+                    ?.DirectoryEntries?.FirstOrDefault(e => e?.ID == (int)ResourceGroupIdType.Version) // Root
                     ?.ResourceDirectory?.DirectoryEntries?.FirstOrDefault() // Type
                     ?.ResourceDirectory?.DirectoryEntries?.FirstOrDefault() // Name
-                    ?.ResourceDataEntry?.OffsetToData; // Language
+                    ?.ResourceDataEntry;
 
-                if (vsVersionOffset is null)
+                if (resourceDataEntry is null || resourceDataEntry.Offset >= resourceDataEntry.PeFile.Length)
                     return null;
 
-                return vsVersionOffset.Value.TryRvaToOffset(_sectionHeaders, out var offset)
+                uint vsVersionOffset = resourceDataEntry.OffsetToData; // Language
+
+                return vsVersionOffset.TryRvaToOffset(_sectionHeaders, out var offset)
                     ? new ResourcesParser(_peFile, 0, offset)
                     : null;
             }


### PR DESCRIPTION
Hi,

In some samples (such as this one: c51c6db202d99c64863d1eb3251f106691685fbe13616b2be666d4d1a322e6b8) PeNet tries to get offsets out of the sample bytes, causing this error:

        Specified argument was out of the range of valid values

I have added a check to prevent this.