### PR TITLE
Mark PeNet as trimmable, enable relevant analyzers, and fix most violations

### DIFF
--- a/src/PeNet/Header/AbstractStructure.cs
+++ b/src/PeNet/Header/AbstractStructure.cs
@@ -32,40 +32,5 @@ namespace PeNet.Header
             PeFile = peFile;
             Offset = offset;
         }
-
-        /// <summary>
-        /// Create a printable string representation of the object.
-        /// </summary>
-        /// <returns>String containing all property-value pairs.</returns>
-        public override string ToString()
-        {
-            var obj = this;
-            var properties = obj.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance);
-            var sb = new StringBuilder();
-            sb.Append($"{obj.GetType().Name}\n");
-
-            foreach (var p in properties)
-            {
-                if (p.PropertyType.IsArray)
-                {
-                    if(p.GetValue(obj, null) == null)
-                        continue;
-
-                    foreach (var entry in (p.GetValue(obj, null) as IEnumerable)!)
-                    {
-                        if (entry.GetType().IsSubclassOf(typeof(AbstractStructure)) == false)
-                            continue;
-
-                        sb.Append(entry);
-                    }
-                }
-                else
-                {
-                    sb.AppendFormat("{0}: {1}\n", p.Name, p.GetValue(obj, null));
-                }
-            }
-
-            return sb.ToString();
-        }
     }
 }

--- a/src/PeNet/Header/Net/MetaDataTablesHdr.cs
+++ b/src/PeNet/Header/Net/MetaDataTablesHdr.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using PeNet.FileParser;
 using PeNet.Header.Net.MetaDataTables;
@@ -374,7 +375,8 @@ namespace PeNet.Header.Net
             return tables;
         }
 
-        private List<T> ParseTable<T>(MetadataToken token)
+        private List<T> ParseTable<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
+            MetadataToken token)
             where T : AbstractTable
         {
             var heapSizes = new HeapSizes(HeapSizes);
@@ -425,7 +427,12 @@ namespace PeNet.Header.Net
         public static List<string> ResolveMaskValid(MaskValidType maskValid)
         {
             var st = new List<string>();
-            foreach (var flag in (MaskValidType[])Enum.GetValues(typeof(MaskValidType)))
+#if NET5_0_OR_GREATER
+            var values = Enum.GetValues<MaskValidType>();
+#else
+            var values = (MaskValidType[])Enum.GetValues(typeof(MaskValidType));
+#endif
+            foreach (var flag in values)
             {
                 if ((maskValid & flag) == flag)
                 {

--- a/src/PeNet/Header/Pe/ImageCor20Header.cs
+++ b/src/PeNet/Header/Pe/ImageCor20Header.cs
@@ -195,7 +195,12 @@ namespace PeNet.Header.Pe
         public static List<string> ResolveComFlags(ComFlagsType comFlags)
         {
             var st = new List<string>();
-            foreach (var flag in (ComFlagsType[])Enum.GetValues(typeof(ComFlagsType)))
+#if NET6_0_OR_GREATER
+            var values = Enum.GetValues<ComFlagsType>();
+#else
+            var values = (ComFlagsType[])Enum.GetValues(typeof(ComFlagsType));
+#endif
+            foreach (var flag in values)
             {
                 if ((comFlags & flag) == flag)
                 {

--- a/src/PeNet/Header/Pe/ImageFileHeader.cs
+++ b/src/PeNet/Header/Pe/ImageFileHeader.cs
@@ -106,7 +106,12 @@ namespace PeNet.Header.Pe
         public static List<string> ResolveFileCharacteristics(FileCharacteristicsType characteristics)
         {
             var st = new List<string>();
-            foreach (var flag in (FileCharacteristicsType[])Enum.GetValues(typeof(FileCharacteristicsType)))
+#if NET5_0_OR_GREATER
+            var values = Enum.GetValues<FileCharacteristicsType>();
+#else
+            var values = (FileCharacteristicsType[])Enum.GetValues(typeof(FileCharacteristicsType));
+#endif
+            foreach (var flag in values)
             {
                 if ((characteristics & flag) == flag)
                 {

--- a/src/PeNet/Header/Pe/ImageSectionHeader.cs
+++ b/src/PeNet/Header/Pe/ImageSectionHeader.cs
@@ -148,7 +148,12 @@ namespace PeNet.Header.Pe
         public static List<string> ResolveCharacteristics(ScnCharacteristicsType sectionFlags)
         {
             var st = new List<string>();
-            foreach (var flag in (ScnCharacteristicsType[])Enum.GetValues(typeof(ScnCharacteristicsType)))
+#if NET5_0_OR_GREATER
+            var values = Enum.GetValues<ScnCharacteristicsType>();
+#else
+            var values = (ScnCharacteristicsType[])Enum.GetValues(typeof(ScnCharacteristicsType));
+#endif
+            foreach (var flag in values)
             {
                 if ((sectionFlags & flag) == flag)
                 {

--- a/src/PeNet/PeNet.csproj
+++ b/src/PeNet/PeNet.csproj
@@ -7,6 +7,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <WarningsAsErrors>CS8600;CS8602;CS8603;CS8625;CS8618;CS8604;CS8601</WarningsAsErrors>
     <IsDotNetFramework Condition=" $(TargetFramework.StartsWith(net4)) or $(TargetFramework.Equals(netstandard2)) ">true</IsDotNetFramework>
+    <PolySharpIncludeRuntimeSupportedAttributes>true</PolySharpIncludeRuntimeSupportedAttributes>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -30,6 +31,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="PolySharp" Version="1.13.2" PrivateAssets="all" />
     <PackageReference Include="PeNet.Asn1" Version="2.0.1" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="7.0.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />

--- a/src/PeNet/PeNet.csproj
+++ b/src/PeNet/PeNet.csproj
@@ -4,6 +4,7 @@
     <Version>0.0.0</Version>
     <Nullable>enable</Nullable>
     <LangVersion>9</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <WarningsAsErrors>CS8600;CS8602;CS8603;CS8625;CS8618;CS8604;CS8601</WarningsAsErrors>
     <IsDotNetFramework Condition=" $(TargetFramework.StartsWith(net4)) or $(TargetFramework.Equals(netstandard2)) ">true</IsDotNetFramework>
   </PropertyGroup>
@@ -26,46 +27,6 @@
     <PackageIconUrl>https://raw.githubusercontent.com/secana/PeNet/master/resource/icon.png</PackageIconUrl>
     <PackageIcon>icon.png</PackageIcon>
     <PackageProjectUrl>https://github.com/secana/PeNet</PackageProjectUrl>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.1|AnyCPU'">
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.1|AnyCPU'">
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2|AnyCPU'">
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2|AnyCPU'">
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-  
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net6.0|AnyCPU'">
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net6.0|AnyCPU'">
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net48|AnyCPU'">
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net48|AnyCPU'">
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net7|AnyCPU'">
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net7|AnyCPU'">
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/PeNet/PeNet.csproj
+++ b/src/PeNet/PeNet.csproj
@@ -10,6 +10,14 @@
     <PolySharpIncludeRuntimeSupportedAttributes>true</PolySharpIncludeRuntimeSupportedAttributes>
   </PropertyGroup>
 
+  <PropertyGroup Condition="!$(TargetFramework.StartsWith(net4)) and !$(TargetFramework.StartsWith(netstandard))">
+    <!-- These 4 properties can be replaced with the umbrella property IsAotCompatible=true in .NET SDK 8. -->
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
+    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <IsTrimmable>true</IsTrimmable>
+  </PropertyGroup>
+
   <PropertyGroup>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/test/PeNet.Test/Header/AbstractStructureTest.cs
+++ b/test/PeNet.Test/Header/AbstractStructureTest.cs
@@ -35,16 +35,5 @@ namespace PeNet.Test.Header
             {
             }
         }
-
-        [Fact]
-        public void ToString_GivenAnAbstractStructure_ReturnsStringRepresentation()
-        {
-            var structure = new Structure();
-            var expected = "Structure\nInteger: 10\nString: Hello\nLong: 20\nNullString: \nSubStructure\nSubInt: 11\nSubString: 12\nSubStructure\nSubInt: 11\nSubString: 12\n";
-
-            var actual = structure.ToString();
-
-            Assert.Equal(expected, actual);
-        }
     }
 }


### PR DESCRIPTION
Fixes #246.

@secana I am not sure what to do about the reflection usage in `AbstractStructure.ToString()`. Unfortunately, we cannot simply mark the method as `[DynamicallyAccessMembers(DynamicallyAccessedMemberTypes.PublicProperties)]` because such an attribute must match the attribute on the base class method (`object.ToString()`) which doesn't have one. Any thoughts on this?