### PR TITLE
Reworked and renamed PeFile.ImageDelayImportDescriptor property

### DIFF
--- a/src/PeNet/HeaderParser/Pe/DataDirectoryParsers.cs
+++ b/src/PeNet/HeaderParser/Pe/DataDirectoryParsers.cs
@@ -71,7 +71,7 @@ namespace PeNet.HeaderParser.Pe
         public ImportFunction[]? ImportFunctions => _importedFunctionsParser.GetParserTarget();
         public ImageBoundImportDescriptor? ImageBoundImportDescriptor => _imageBoundImportDescriptorParser?.GetParserTarget();
         public ImageTlsDirectory? ImageTlsDirectory => _imageTlsDirectoryParser?.GetParserTarget();
-        public ImageDelayImportDescriptor? ImageDelayImportDescriptor => _imageDelayImportDescriptorParser?.GetParserTarget();
+        public ImageDelayImportDescriptor[]? ImageDelayImportDescriptors => _imageDelayImportDescriptorParser?.GetParserTarget();
         public ImageLoadConfigDirectory? ImageLoadConfigDirectory => _imageLoadConfigDirectoryParser?.GetParserTarget();
         public ImageCor20Header? ImageComDescriptor => _imageCor20HeaderParser?.GetParserTarget();
         public Resources? Resources => _resourcesParser?.GetParserTarget();

--- a/src/PeNet/HeaderParser/Pe/ImageDelayImportDescriptorParser.cs
+++ b/src/PeNet/HeaderParser/Pe/ImageDelayImportDescriptorParser.cs
@@ -1,18 +1,47 @@
 ﻿using PeNet.FileParser;
 using PeNet.Header.Pe;
+using System.Collections.Generic;
 
 namespace PeNet.HeaderParser.Pe
 {
-    internal class ImageDelayImportDescriptorParser : SafeParser<ImageDelayImportDescriptor>
+    internal class ImageDelayImportDescriptorParser : SafeParser<ImageDelayImportDescriptor[]>
     {
         internal ImageDelayImportDescriptorParser(IRawFile peFile, long offset) 
             : base(peFile, offset)
         {
         }
 
-        protected override ImageDelayImportDescriptor ParseTarget()
+        protected override ImageDelayImportDescriptor[]? ParseTarget()
         {
-            return new ImageDelayImportDescriptor(PeFile, Offset);
+            if (Offset == 0)
+                return null;
+
+            var idescs = new List<ImageDelayImportDescriptor>();
+            uint idescSize = 32; // Size of ImageDelayImportDescriptor (8 * 4 Byte)
+            int round = 0;
+
+            while (true)
+            {
+                var idesc = new ImageDelayImportDescriptor(PeFile, Offset + idescSize * round);
+
+                // Find the last ImageDelayImportDescriptor which is completely null (except for TimeDateStamp member).
+                if (idesc.GrAttrs == 0
+                    && idesc.SzName == 0
+                    && idesc.Phmod == 0
+                    && idesc.PIat == 0
+                    && idesc.PInt == 0
+                    && idesc.PBoundIAT == 0
+                    && idesc.PUnloadIAT == 0
+                    )
+                {
+                    break;
+                }
+
+                idescs.Add(idesc);
+                round++;
+            }
+
+            return idescs.ToArray();
         }
     }
 }

--- a/src/PeNet/PeFile.cs
+++ b/src/PeNet/PeFile.cs
@@ -366,8 +366,8 @@ namespace PeNet
         /// <summary>
         /// Access the ImageDelayImportDirectory from the data directory.
         /// </summary>
-        public ImageDelayImportDescriptor? ImageDelayImportDescriptor =>
-            _dataDirectoryParsers?.ImageDelayImportDescriptor;
+        public ImageDelayImportDescriptor[]? ImageDelayImportDescriptors =>
+            _dataDirectoryParsers?.ImageDelayImportDescriptors;
 
         /// <summary>
         /// Access the ImageLoadConfigDirectory from the data directory.


### PR DESCRIPTION
Reworked and renamed PeFile.ImageDelayImportDescriptor property, now is ImageDelayImportDescriptor[] ImageDelayImportDescriptors.

ImageDelayImportDescriptor used to return the first delay import descriptor only, now it works similar to ImageImportDescriptors. 

Although it seems to work correctly now, this change may break existing code that uses PeNet, what do you think? 