### PR TITLE
Added DelayImportedFunctions property to PeFile

### DIFF
--- a/src/PeNet/HeaderParser/Pe/DataDirectoryParsers.cs
+++ b/src/PeNet/HeaderParser/Pe/DataDirectoryParsers.cs
@@ -22,6 +22,7 @@ namespace PeNet.HeaderParser.Pe
         private ImageImportDescriptorsParser? _imageImportDescriptorsParser;
         private readonly ImageResourceDirectoryParser? _imageResourceDirectoryParser;
         private ImportedFunctionsParser _importedFunctionsParser;
+        private readonly DelayImportedFunctionsParser _delayImportedFunctionsParser;
         private readonly RuntimeFunctionsParser? _runtimeFunctionsParser;
         private readonly WinCertificateParser? _winCertificateParser;
         private readonly ImageTlsDirectoryParser? _imageTlsDirectoryParser;
@@ -46,15 +47,16 @@ namespace PeNet.HeaderParser.Pe
             _imageExportDirectoriesParser = InitImageExportDirectoryParser();
             _runtimeFunctionsParser = InitRuntimeFunctionsParser();
             _imageImportDescriptorsParser = InitImageImportDescriptorsParser();
+            _imageDelayImportDescriptorParser = InitImageDelayImportDescriptorParser();
             _imageBaseRelocationsParser = InitImageBaseRelocationsParser();
             _imageResourceDirectoryParser = InitImageResourceDirectoryParser();
             _imageDebugDirectoryParser = InitImageDebugDirectoryParser();
             _winCertificateParser = InitWinCertificateParser();
             _exportedFunctionsParser = InitExportFunctionParser();
             _importedFunctionsParser = InitImportedFunctionsParser();
+            _delayImportedFunctionsParser = InitDelayImportedFunctionsParser();
             _imageBoundImportDescriptorParser = InitBoundImportDescriptorParser();
             _imageTlsDirectoryParser = InitImageTlsDirectoryParser();
-            _imageDelayImportDescriptorParser = InitImageDelayImportDescriptorParser();
             _imageLoadConfigDirectoryParser = InitImageLoadConfigDirectoryParser();
             _imageCor20HeaderParser = InitImageComDescriptorParser();
             _resourcesParser = InitResourcesParser();
@@ -69,6 +71,7 @@ namespace PeNet.HeaderParser.Pe
         public RuntimeFunction[]? RuntimeFunctions => _runtimeFunctionsParser?.GetParserTarget();
         public ExportFunction[]? ExportFunctions => _exportedFunctionsParser.GetParserTarget();
         public ImportFunction[]? ImportFunctions => _importedFunctionsParser.GetParserTarget();
+        public ImportFunction[]? DelayImportFunctions => _delayImportedFunctionsParser?.GetParserTarget();
         public ImageBoundImportDescriptor? ImageBoundImportDescriptor => _imageBoundImportDescriptorParser?.GetParserTarget();
         public ImageTlsDirectory? ImageTlsDirectory => _imageTlsDirectoryParser?.GetParserTarget();
         public ImageDelayImportDescriptor[]? ImageDelayImportDescriptors => _imageDelayImportDescriptorParser?.GetParserTarget();
@@ -152,6 +155,15 @@ namespace PeNet.HeaderParser.Pe
             => new(
                 _peFile,
                 ImageImportDescriptors,
+                _sectionHeaders,
+                _dataDirectories,
+                !_is32Bit
+                );
+
+        private DelayImportedFunctionsParser InitDelayImportedFunctionsParser()
+            => new(
+                _peFile,
+                ImageDelayImportDescriptors,
                 _sectionHeaders,
                 _dataDirectories,
                 !_is32Bit

--- a/src/PeNet/HeaderParser/Pe/DelayImportedFunctionsParser.cs
+++ b/src/PeNet/HeaderParser/Pe/DelayImportedFunctionsParser.cs
@@ -1,0 +1,86 @@
+﻿using System.Collections.Generic;
+using PeNet.FileParser;
+using PeNet.Header.Pe;
+
+namespace PeNet.HeaderParser.Pe
+{
+    internal class DelayImportedFunctionsParser : SafeParser<ImportFunction[]>
+    {
+        private readonly ImageDelayImportDescriptor[]? _importDescriptors;
+        private readonly bool _is64Bit;
+        private readonly ImageSectionHeader[] _sectionHeaders;
+        private readonly ImageDataDirectory[] _dataDirectories;
+
+        internal DelayImportedFunctionsParser(
+            IRawFile peFile,
+            ImageDelayImportDescriptor[]? importDescriptors,
+            ImageSectionHeader[] sectionHeaders,
+            ImageDataDirectory[] dataDirectories,
+            bool is64Bit) :
+                base(peFile, 0)
+        {
+            _importDescriptors = importDescriptors;
+            _sectionHeaders = sectionHeaders;
+            _dataDirectories = dataDirectories;
+            _is64Bit = is64Bit;
+        }
+
+        protected override ImportFunction[]? ParseTarget()
+        {
+            if (_importDescriptors == null)
+                return null;
+
+            var impFuncs = new List<ImportFunction>();
+            var sizeOfThunk = (uint)(_is64Bit ? 0x8 : 0x4); // Size of ImageThunkData
+            var ordinalBit = _is64Bit ? 0x8000000000000000 : 0x80000000;
+            var ordinalMask = (ulong)(_is64Bit ? 0x7FFFFFFFFFFFFFFF : 0x7FFFFFFF);
+            var iat = _dataDirectories[(int)DataDirectoryType.DelayImport];
+
+            foreach (var idesc in _importDescriptors)
+            {
+                var dllAdr = idesc.SzName.RvaToOffset(_sectionHeaders);
+                var dll = PeFile.ReadAsciiString(dllAdr);
+                if (IsModuleNameTooLong(dll))
+                    continue;
+                var tmpAdr = idesc.PInt;
+                if (tmpAdr == 0)
+                    continue;
+
+                var thunkAdr = tmpAdr.RvaToOffset(_sectionHeaders);
+                uint round = 0; 
+
+                while (true)
+                {
+                    var t = new ImageThunkData(PeFile, thunkAdr + round * sizeOfThunk, _is64Bit);
+                    var iatOffset = idesc.PInt + round * sizeOfThunk - iat.VirtualAddress;
+
+                    if (t.AddressOfData == 0)
+                        break;
+
+                    // Check if import by name or by ordinal.
+                    // If it is an import by ordinal, the most significant bit of "Ordinal" is "1" and the ordinal can
+                    // be extracted from the least significant bits.
+                    // Else it is an import by name and the link to the ImageImportByName has to be followed
+
+                    if ((t.Ordinal & ordinalBit) == ordinalBit) // Import by ordinal
+                    {
+                        impFuncs.Add(new ImportFunction(null, dll, (ushort)(t.Ordinal & ordinalMask), iatOffset));
+                    }
+                    else // Import by name
+                    {
+                        var ibn = new ImageImportByName(PeFile,
+                            ((uint)t.AddressOfData).RvaToOffset(_sectionHeaders));
+                        impFuncs.Add(new ImportFunction(ibn.Name, dll, ibn.Hint, iatOffset));
+                    }
+
+                    round++;
+                }
+            }
+
+            return impFuncs.ToArray();
+        }
+
+        private bool IsModuleNameTooLong(string dllName)
+            => dllName.Length > 256;
+    }
+}

--- a/src/PeNet/PeFile.cs
+++ b/src/PeNet/PeFile.cs
@@ -333,6 +333,11 @@ namespace PeNet
         public ImportFunction[]? ImportedFunctions => _dataDirectoryParsers?.ImportFunctions;
 
         /// <summary>
+        ///     Access the delay imported functions as an array of parsed objects.
+        /// </summary>
+        public ImportFunction[]? DelayImportedFunctions => _dataDirectoryParsers?.DelayImportFunctions;
+        
+        /// <summary>
         ///     Access the ImageResourceDirectory of the PE file.
         /// </summary>
         public ImageResourceDirectory? ImageResourceDirectory => _dataDirectoryParsers?.ImageResourceDirectory;

--- a/test/PeNet.Test/PeFileTest.cs
+++ b/test/PeNet.Test/PeFileTest.cs
@@ -21,6 +21,16 @@ namespace PeNet.Test
         }
 
         [Fact]
+        public void ImportedFunction_DelayImport_ParsedDelayImports()
+        {
+            var peFile = new PeFile(@"Binaries/chrome_elf.dll");
+
+            Assert.NotNull(peFile.DelayImportedFunctions.FirstOrDefault(
+                i => i.DLL == "WINMM.dll" &&
+                i.Name == "timeGetTime"));
+        }
+
+        [Fact]
         public void ExportedFunctions_WithForwardedFunctions_ParsedForwardedFunctions()
         {
             var peFile = new PeFile(@"Binaries/win_test.dll");


### PR DESCRIPTION
Changes:
- added DelayImportedFunctions property as an array of parsed ImportFunction objects to the PeFile class;
- added a test condition to PeFileTest.cs, to check if the property works correctly. 